### PR TITLE
Update dependencies (and remove the rash gem)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Judopay
+# Judopay Ruby SDK
 
-The judoPay gem is currently not actively supported by judo, but it is available here for anyone who wish to use it as a platform to develop upon. 
+The judopay gem is not actively supported by judo, but it is available here for anyone who wish to use it as a platform to develop upon. 
 This gem supports Ruby 1.9.3 and above (including 2.0.x and 2.1.x).
 
 [![Build Status](https://travis-ci.org/JudoPay/RubySdk.svg?branch=master)](https://travis-ci.org/JudoPay/RubySdk)

--- a/judopay.gemspec
+++ b/judopay.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rake'
   spec.add_dependency 'virtus', '~> 1.0.2'
   spec.add_dependency 'httpclient', '~> 2.4.0'
-  spec.add_dependency 'activemodel', '~> 4.1.1'
+  spec.add_dependency 'activemodel', ['~> 4.1', '~> 4.2']
   spec.add_dependency 'faraday', '~> 0.9.0'
   spec.add_dependency 'faraday_middleware', '~> 0.9.1'
   spec.add_dependency 'hashie', '~> 3.4.6'

--- a/judopay.gemspec
+++ b/judopay.gemspec
@@ -33,6 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activemodel', '~> 4.1.1'
   spec.add_dependency 'faraday', '~> 0.9.0'
   spec.add_dependency 'faraday_middleware', '~> 0.9.1'
-  spec.add_dependency 'rash', '~> 0.4.0'
+  spec.add_dependency 'hashie', '~> 3.4.6'
   spec.add_dependency 'addressable', '~> 2.3.6'
 end

--- a/lib/faraday/judo_mashify.rb
+++ b/lib/faraday/judo_mashify.rb
@@ -1,12 +1,10 @@
-require 'faraday_middleware/response/rashify'
 require_relative '../judopay/mash'
 
 # @private
 module FaradayMiddleware
-  # Convert parsed response bodies to a Hashie::Rash if they are a Hash or Array
-  class JudoMashify < Rashify
+  # Convert parsed response bodies to a Hashie::Mash if they are a Hash or Array
+  class JudoMashify < Mashify
     dependency do
-      require 'rash'
       self.mash_class = ::Judopay::Mash
     end
   end

--- a/lib/judopay/mash.rb
+++ b/lib/judopay/mash.rb
@@ -1,7 +1,20 @@
 require 'hashie'
-require 'rash'
 
 module Judopay
-  class Mash < ::Hashie::Rash
+  class Mash < ::Hashie::Mash
+
+    protected
+
+    def convert_key(key)
+      camelcase_to_underscore(key.to_s)
+    end
+
+    def camelcase_to_underscore(string)
+      string.gsub(/::/, '/').
+      gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2').
+      gsub(/([a-z\d])([A-Z])/,'\1_\2').
+      tr("-", "_").
+      downcase
+    end
   end
 end

--- a/lib/judopay/mash.rb
+++ b/lib/judopay/mash.rb
@@ -6,15 +6,7 @@ module Judopay
     protected
 
     def convert_key(key)
-      camelcase_to_underscore(key.to_s)
-    end
-
-    def camelcase_to_underscore(string)
-      string.gsub(/::/, '/').
-      gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2').
-      gsub(/([a-z\d])([A-Z])/,'\1_\2').
-      tr("-", "_").
-      downcase
+      key.to_s.underscore
     end
   end
 end


### PR DESCRIPTION
* Update the active model dependencies to allow 4.2.x as well as 4.1.x
* Remove the dependency on the unmaintained rash gem, and instead introduce a simple method to convert camel case to underscored method names