### PR TITLE
Cv2 not require for save card

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .bundle
 .config
 .yardoc
+.idea
 Gemfile.lock
 InstalledFiles
 _yardoc

--- a/lib/judopay/error.rb
+++ b/lib/judopay/error.rb
@@ -26,7 +26,9 @@ module Judopay
     CATEGORY_PROCESSING = 4
     CATEGORY_EXCEPTION = 5
 
-    attr_accessor :message, :error_code, :status_code, :category, :field_errors
+    attr_accessor :error_code, :status_code, :category, :field_errors
+
+    attr_writer :message
 
     class << self
       def factory(response)

--- a/lib/judopay/models/inner/transmitted_field.rb
+++ b/lib/judopay/models/inner/transmitted_field.rb
@@ -27,7 +27,7 @@ module Judopay
 
       def parse_string(string)
         JSON.parse(string)
-      rescue
+      rescue StandardError
         raise Judopay::ValidationError, format(WRONG_JSON_ERROR_MESSAGE, name)
       end
     end

--- a/lib/judopay/models/save_card.rb
+++ b/lib/judopay/models/save_card.rb
@@ -19,7 +19,6 @@ module Judopay
 
     validates_presence_of :your_consumer_reference,
                           :card_number,
-                          :expiry_date,
-                          :cv2
+                          :expiry_date
   end
 end

--- a/test/save_card_test.rb
+++ b/test/save_card_test.rb
@@ -1,7 +1,6 @@
 require 'base/integration_base'
 
 class SaveCardTests < IntegrationBase
-
   def get_model(params = {})
     build(:save_card, params)
   end

--- a/test/save_card_test.rb
+++ b/test/save_card_test.rb
@@ -1,4 +1,3 @@
-require 'base/payments_tests'
 require 'base/integration_base'
 
 class SaveCardTests < IntegrationBase

--- a/test/save_card_test.rb
+++ b/test/save_card_test.rb
@@ -1,0 +1,25 @@
+require 'base/payments_tests'
+require 'base/integration_base'
+
+class SaveCardTests < IntegrationBase
+
+  def get_model(params = {})
+    build(:save_card, params)
+  end
+
+  def test_valid_payment
+    result = get_model.create
+    TestHelpers::AssertionHelper.assert_successful_payment(result)
+  end
+
+  def test_payment_without_reference
+    assert_raise(Judopay::ValidationError.new("Missing required fields\nField errors:\nyour_consumer_reference: can't be blank")) do
+      get_model(:your_consumer_reference => nil).create
+    end
+  end
+
+  def test_save_card_with_no_cv2
+    result = get_model(:cv2 => '').create
+    TestHelpers::AssertionHelper.assert_successful_payment(result)
+  end
+end


### PR DESCRIPTION
We do not require CV2 on the server for save card calls. This removes the validation for the field