### PR TITLE
Upgrade the Faraday gems

### DIFF
--- a/judopay.gemspec
+++ b/judopay.gemspec
@@ -31,8 +31,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'virtus', '~> 1.0.2'
   spec.add_dependency 'httpclient', '~> 2.4.0'
   spec.add_dependency 'activemodel', ['~> 4.1', '~> 4.2']
-  spec.add_dependency 'faraday', '~> 0.14'
-  spec.add_dependency 'faraday_middleware', '~> 0.12'
+  spec.add_dependency 'faraday', '~> 0.9'
+  spec.add_dependency 'faraday_middleware', '~> 0.9'
   spec.add_dependency 'hashie', '~> 3.4.6'
   spec.add_dependency 'addressable', '~> 2.3.6'
 end

--- a/judopay.gemspec
+++ b/judopay.gemspec
@@ -31,8 +31,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'virtus', '~> 1.0.2'
   spec.add_dependency 'httpclient', '~> 2.4.0'
   spec.add_dependency 'activemodel', ['~> 4.1', '~> 4.2']
-  spec.add_dependency 'faraday', '~> 0.9.0'
-  spec.add_dependency 'faraday_middleware', '~> 0.9.1'
+  spec.add_dependency 'faraday', '~> 0.14'
+  spec.add_dependency 'faraday_middleware', '~> 0.12'
   spec.add_dependency 'hashie', '~> 3.4.6'
   spec.add_dependency 'addressable', '~> 2.3.6'
 end

--- a/lib/judopay/connection.rb
+++ b/lib/judopay/connection.rb
@@ -10,14 +10,14 @@ module Judopay
     private
 
     def connection(raw = false)
-      connection = Faraday::Connection.new(default_connection_options) do |faraday|
-        # When adapter set to "httpclient" SSL error emerges after bunch of requests:
-        # "Faraday::SSLError: SSL_connect SYSCALL returned=5 errno=0 state=SSLv2/v3 read server hello A"
-        faraday.adapter :net_http
+      connection = Faraday.new(default_connection_options) do |faraday|
         faraday.use Faraday::Request::UrlEncoded
         faraday.use Faraday::Response::Logger, Judopay.configuration.logger
         define_format(faraday, raw)
         faraday.use FaradayMiddleware::RaiseHttpException
+        # When adapter set to "httpclient" SSL error emerges after bunch of requests:
+        # "Faraday::SSLError: SSL_connect SYSCALL returned=5 errno=0 state=SSLv2/v3 read server hello A"
+        faraday.adapter :net_http
       end
 
       define_auth(connection)


### PR DESCRIPTION
Also change the order of the middlewares defined within the Faraday connection, as from v1 of Faraday, the adapter must be set *after* the other middlewares (https://github.com/lostisland/faraday/blob/936e57879bb41bd572f91795c9b5d30e794cebbe/lib/faraday/rack_builder.rb#L208)