### PR TITLE
Upgrade the Addressable gem

### DIFF
--- a/judopay.gemspec
+++ b/judopay.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday', '~> 0.9.0'
   spec.add_dependency 'faraday_middleware', '~> 0.9.1'
   spec.add_dependency 'hashie', '~> 3.4.6'
-  spec.add_dependency 'addressable', '~> 2.3.6'
+  spec.add_dependency 'addressable', '~> 2.3'
 end


### PR DESCRIPTION
Allow versions of addressable higher than 2.3