### PR TITLE
Upgrade gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in judopay.gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 require 'rake/testtask'
@@ -6,6 +8,7 @@ RSpec::Core::RakeTask.new
 
 Rake::TestTask.new do |t|
   raise 'Please setup JUDO_* environment vars' unless ENV['JUDO_API_ID'] && ENV['JUDO_API_TOKEN'] && ENV['JUDO_API_SECRET']
+
   t.libs << 'test'
   t.test_files = FileList['test/*_test.rb']
   t.verbose = true

--- a/judopay.gemspec
+++ b/judopay.gemspec
@@ -31,8 +31,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'virtus', '~> 1.0.2'
   spec.add_dependency 'httpclient', '~> 2.4'
   spec.add_dependency 'activemodel', ['~> 4.1', '~> 4.2']
-  spec.add_dependency 'faraday'
+  spec.add_dependency 'faraday', '~> 0.9'
   spec.add_dependency 'faraday_middleware', '~> 0.9'
-  spec.add_dependency 'hashie', '>= 3.5.2'
+  spec.add_dependency 'hashie', ['~>3.5', '>= 3.5.2']
   spec.add_dependency 'addressable', '~> 2.3'
 end

--- a/judopay.gemspec
+++ b/judopay.gemspec
@@ -33,6 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activemodel', ['~> 4.1', '~> 4.2']
   spec.add_dependency 'faraday'
   spec.add_dependency 'faraday_middleware', '~> 0.9'
-  spec.add_dependency 'hashie', '~> 3.4.6'
+  spec.add_dependency 'hashie', '>= 3.5.2'
   spec.add_dependency 'addressable', '~> 2.3'
 end

--- a/judopay.gemspec
+++ b/judopay.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'virtus', '~> 1.0.2'
   spec.add_dependency 'httpclient', '~> 2.4'
   spec.add_dependency 'activemodel', ['~> 4.1', '~> 4.2']
-  spec.add_dependency 'faraday', '~> 0.9'
+  spec.add_dependency 'faraday'
   spec.add_dependency 'faraday_middleware', '~> 0.9'
   spec.add_dependency 'hashie', '~> 3.4.6'
   spec.add_dependency 'addressable', '~> 2.3'

--- a/lib/faraday/judo_mashify.rb
+++ b/lib/faraday/judo_mashify.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../judopay/mash'
 
 # @private

--- a/lib/faraday/raise_http_exception.rb
+++ b/lib/faraday/raise_http_exception.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'faraday'
 require_relative '../judopay/error'
 

--- a/lib/judopay.rb
+++ b/lib/judopay.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'judopay/version'
 require_relative 'judopay/api'
 require_relative 'judopay/response'
@@ -21,6 +23,7 @@ module Judopay
   def self.log(log_level, message)
     logger = self.configuration.logger
     return unless logger.is_a?(Logger)
+
     logger.progname = 'judopay'
     logger.add(log_level) { message }
   end
@@ -64,6 +67,7 @@ module Judopay
 
     def validate
       return true unless judo_id.to_s.empty? || api_token.to_s.empty? || api_secret.to_s.empty?
+
       raise Judopay::ValidationError, 'SDK configuration variables missing'
     end
   end

--- a/lib/judopay/api.rb
+++ b/lib/judopay/api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path('connection', __dir__)
 require File.expand_path('request', __dir__)
 

--- a/lib/judopay/connection.rb
+++ b/lib/judopay/connection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'faraday'
 require 'faraday_middleware'
 require 'openssl'
@@ -25,6 +27,7 @@ module Judopay
 
     def define_format(faraday, raw)
       return if raw
+
       faraday.use FaradayMiddleware::JudoMashify
       faraday.use Faraday::Response::ParseJson if Judopay.configuration.format.to_s == 'json'
     end

--- a/lib/judopay/core_ext/hash.rb
+++ b/lib/judopay/core_ext/hash.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'addressable/uri'
 require_relative 'string'
 

--- a/lib/judopay/core_ext/string.rb
+++ b/lib/judopay/core_ext/string.rb
@@ -1,9 +1,12 @@
+# frozen_string_literal: true
+
 class String
   # Convert to camel case
   #
   #   "foo_bar".camel_case          #=> "fooBar"
   def camel_case
     return self if self !~ /_/ && self =~ /[A-Z]+.*/
+
     split('_').map(&:capitalize).join.uncapitalize
   end
 

--- a/lib/judopay/error.rb
+++ b/lib/judopay/error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 
 module Judopay
@@ -80,6 +82,7 @@ module Judopay
 
     def field_errors_message
       return '' if @field_errors.empty?
+
       "\nFields errors:\n#{@field_errors.join("\n")}"
     end
   end
@@ -100,6 +103,7 @@ module Judopay
 
     def model_errors
       return if @errors.nil?
+
       @errors.messages
     end
 

--- a/lib/judopay/mash.rb
+++ b/lib/judopay/mash.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'hashie'
 
 module Judopay

--- a/lib/judopay/model.rb
+++ b/lib/judopay/model.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'addressable/uri'
 require 'virtus'
 require 'active_model'
@@ -50,6 +52,7 @@ module Judopay
         valid_options = {}
         options.each do |key, value|
           next unless VALID_PAGING_OPTIONS.include?(key)
+
           valid_options[key] = value
         end
         valid_options
@@ -101,6 +104,7 @@ module Judopay
     # Use judo_id from configuration if it hasn't been explicitly set
     def check_judo_id
       return unless respond_to?('judo_id') && judo_id.nil?
+
       self.judo_id = Judopay.configuration.judo_id
     end
 

--- a/lib/judopay/models/android_payment.rb
+++ b/lib/judopay/models/android_payment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../model'
 require_relative 'inner/wallet'
 

--- a/lib/judopay/models/android_preauth.rb
+++ b/lib/judopay/models/android_preauth.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../model'
 require_relative 'android_payment'
 

--- a/lib/judopay/models/apple_payment.rb
+++ b/lib/judopay/models/apple_payment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../model'
 require_relative 'inner/pk_payment'
 

--- a/lib/judopay/models/apple_preauth.rb
+++ b/lib/judopay/models/apple_preauth.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../model'
 require_relative 'apple_payment'
 

--- a/lib/judopay/models/card_address.rb
+++ b/lib/judopay/models/card_address.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../model'
 
 module Judopay

--- a/lib/judopay/models/card_payment.rb
+++ b/lib/judopay/models/card_payment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../model'
 require_relative 'payment'
 require_relative 'card_address'

--- a/lib/judopay/models/card_preauth.rb
+++ b/lib/judopay/models/card_preauth.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../model'
 require_relative 'payment'
 require_relative 'card_address'

--- a/lib/judopay/models/collection.rb
+++ b/lib/judopay/models/collection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../model'
 
 module Judopay

--- a/lib/judopay/models/encrypt_details.rb
+++ b/lib/judopay/models/encrypt_details.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../model'
 
 module Judopay

--- a/lib/judopay/models/inner/pk_payment.rb
+++ b/lib/judopay/models/inner/pk_payment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'transmitted_field'
 require_relative 'pk_payment_token'
 

--- a/lib/judopay/models/inner/pk_payment_token.rb
+++ b/lib/judopay/models/inner/pk_payment_token.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../model'
 
 module Judopay

--- a/lib/judopay/models/inner/transmitted_field.rb
+++ b/lib/judopay/models/inner/transmitted_field.rb
@@ -1,11 +1,13 @@
+# frozen_string_literal: true
+
 require_relative '../../model'
 require 'judopay/mash'
 require 'json'
 
 module Judopay
   class TransmittedField < Model
-    WRONG_OBJECT_ERROR_MESSAGE = 'You passed wrong value to the %<foo>s. Please pass Hash or json-encoded string'.freeze
-    WRONG_JSON_ERROR_MESSAGE = 'Can\'t decode %<foo>s object from JSON'.freeze
+    WRONG_OBJECT_ERROR_MESSAGE = 'You passed wrong value to the %<foo>s. Please pass Hash or json-encoded string'
+    WRONG_JSON_ERROR_MESSAGE = 'Can\'t decode %<foo>s object from JSON'
 
     class << self
       attr_accessor :field_name
@@ -19,6 +21,7 @@ module Judopay
       def validate_data(data)
         data = parse_string(data) if data.is_a?(String)
         raise Judopay::ValidationError, format(WRONG_OBJECT_ERROR_MESSAGE, :foo => name) unless data.is_a?(Hash) || data.is_a?(Judopay::Mash)
+
         data = Judopay::Mash.new(data)
         data = data[field_name] if data.key?(field_name)
 

--- a/lib/judopay/models/inner/wallet.rb
+++ b/lib/judopay/models/inner/wallet.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'transmitted_field'
 
 module Judopay

--- a/lib/judopay/models/market/collection.rb
+++ b/lib/judopay/models/market/collection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../model'
 
 module Judopay

--- a/lib/judopay/models/market/payment.rb
+++ b/lib/judopay/models/market/payment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../model'
 
 module Judopay

--- a/lib/judopay/models/market/preauth.rb
+++ b/lib/judopay/models/market/preauth.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../model'
 
 module Judopay

--- a/lib/judopay/models/market/refund.rb
+++ b/lib/judopay/models/market/refund.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../model'
 
 module Judopay

--- a/lib/judopay/models/market/transaction.rb
+++ b/lib/judopay/models/market/transaction.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../model'
 
 module Judopay

--- a/lib/judopay/models/one_use_token_payment.rb
+++ b/lib/judopay/models/one_use_token_payment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../model'
 require_relative 'payment'
 require_relative 'card_address'

--- a/lib/judopay/models/payment.rb
+++ b/lib/judopay/models/payment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../model'
 
 module Judopay

--- a/lib/judopay/models/preauth.rb
+++ b/lib/judopay/models/preauth.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../model'
 
 module Judopay

--- a/lib/judopay/models/refund.rb
+++ b/lib/judopay/models/refund.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../model'
 
 module Judopay

--- a/lib/judopay/models/register_card.rb
+++ b/lib/judopay/models/register_card.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../model'
 require_relative 'payment'
 require_relative 'card_address'

--- a/lib/judopay/models/save_card.rb
+++ b/lib/judopay/models/save_card.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../model'
 require_relative 'payment'
 require_relative 'card_address'

--- a/lib/judopay/models/token_payment.rb
+++ b/lib/judopay/models/token_payment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../model'
 require_relative 'payment'
 require_relative 'card_address'

--- a/lib/judopay/models/token_preauth.rb
+++ b/lib/judopay/models/token_preauth.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../model'
 require_relative 'token_payment'
 

--- a/lib/judopay/models/transaction.rb
+++ b/lib/judopay/models/transaction.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../model'
 
 module Judopay

--- a/lib/judopay/models/void.rb
+++ b/lib/judopay/models/void.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../model'
 
 module Judopay

--- a/lib/judopay/models/web_payments/payment.rb
+++ b/lib/judopay/models/web_payments/payment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../model'
 require_relative 'web_payment_operation'
 

--- a/lib/judopay/models/web_payments/preauth.rb
+++ b/lib/judopay/models/web_payments/preauth.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../model'
 
 module Judopay

--- a/lib/judopay/models/web_payments/transaction.rb
+++ b/lib/judopay/models/web_payments/transaction.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../model'
 
 module Judopay

--- a/lib/judopay/models/web_payments/web_payment_operation.rb
+++ b/lib/judopay/models/web_payments/web_payment_operation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Judopay
   module WebPayments
     module WebPaymentOperation

--- a/lib/judopay/null_logger.rb
+++ b/lib/judopay/null_logger.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'logger'
 
 module Judopay

--- a/lib/judopay/request.rb
+++ b/lib/judopay/request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'openssl'
 require 'json'
 
@@ -44,6 +46,7 @@ module Judopay
       Judopay.log(Logger::DEBUG, response)
 
       return response if raw
+
       Response.create(response.body)
     end
   end

--- a/lib/judopay/response.rb
+++ b/lib/judopay/response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Judopay
   module Response
     def self.create(response_hash)

--- a/lib/judopay/serializer.rb
+++ b/lib/judopay/serializer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Judopay
   # @private
   class Serializer

--- a/lib/judopay/version.rb
+++ b/lib/judopay/version.rb
@@ -1,4 +1,6 @@
+# frozen_string_literal: true
+
 module Judopay
-  SDK_VERSION = '2.1.4'.freeze
-  API_VERSION = '5.2.0'.freeze
+  SDK_VERSION = '2.1.4'
+  API_VERSION = '5.2.0'
 end

--- a/spec/faraday/response_spec.rb
+++ b/spec/faraday/response_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Faraday::Response do

--- a/spec/judopay/android_payment_spec.rb
+++ b/spec/judopay/android_payment_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require_relative '../../lib/judopay/models/android_payment'
 

--- a/spec/judopay/apple_payment_spec.rb
+++ b/spec/judopay/apple_payment_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'json'
 require_relative '../../lib/judopay/models/apple_payment'

--- a/spec/judopay/card_address_spec.rb
+++ b/spec/judopay/card_address_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require_relative '../../lib/judopay/models/card_address'
 

--- a/spec/judopay/card_payment_spec.rb
+++ b/spec/judopay/card_payment_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require_relative '../../lib/judopay/models/card_payment'
 

--- a/spec/judopay/card_preauth_spec.rb
+++ b/spec/judopay/card_preauth_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require_relative '../../lib/judopay/models/card_preauth'
 

--- a/spec/judopay/collection_spec.rb
+++ b/spec/judopay/collection_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require_relative '../../lib/judopay/models/collection'
 

--- a/spec/judopay/core_ext/hash_spec.rb
+++ b/spec/judopay/core_ext/hash_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require_relative '../../../lib/judopay/core_ext/hash'
 

--- a/spec/judopay/core_ext/string_spec.rb
+++ b/spec/judopay/core_ext/string_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require_relative '../../../lib/judopay/core_ext/string'
 

--- a/spec/judopay/error_spec.rb
+++ b/spec/judopay/error_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require_relative '../../lib/judopay/error'
 require 'active_model'

--- a/spec/judopay/judopay_spec.rb
+++ b/spec/judopay/judopay_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require_relative '../../lib/judopay/models/preauth'
 

--- a/spec/judopay/market/collection_spec.rb
+++ b/spec/judopay/market/collection_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require_relative '../../../lib/judopay/models/market/collection'
 

--- a/spec/judopay/market/payment_spec.rb
+++ b/spec/judopay/market/payment_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require_relative '../../../lib/judopay/models/market/payment'
 

--- a/spec/judopay/market/preauth_spec.rb
+++ b/spec/judopay/market/preauth_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require_relative '../../../lib/judopay/models/market/preauth'
 

--- a/spec/judopay/market/refund_spec.rb
+++ b/spec/judopay/market/refund_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require_relative '../../../lib/judopay/models/market/refund'
 

--- a/spec/judopay/market/transaction_spec.rb
+++ b/spec/judopay/market/transaction_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require_relative '../../../lib/judopay/models/market/transaction'
 

--- a/spec/judopay/payment_spec.rb
+++ b/spec/judopay/payment_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require_relative '../../lib/judopay/models/payment'
 

--- a/spec/judopay/preauth_spec.rb
+++ b/spec/judopay/preauth_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require_relative '../../lib/judopay/models/preauth'
 

--- a/spec/judopay/refund_spec.rb
+++ b/spec/judopay/refund_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require_relative '../../lib/judopay/models/refund'
 

--- a/spec/judopay/register_card_spec.rb
+++ b/spec/judopay/register_card_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require_relative '../../lib/judopay/models/register_card'
 

--- a/spec/judopay/save_card_spec.rb
+++ b/spec/judopay/save_card_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require_relative '../../lib/judopay/models/save_card'
 

--- a/spec/judopay/token_payment_spec.rb
+++ b/spec/judopay/token_payment_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require_relative '../../lib/judopay/models/token_preauth'
 

--- a/spec/judopay/token_preauth_spec.rb
+++ b/spec/judopay/token_preauth_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require_relative '../../lib/judopay/models/token_preauth'
 

--- a/spec/judopay/transaction_spec.rb
+++ b/spec/judopay/transaction_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require_relative '../../lib/judopay/models/transaction'
 

--- a/spec/judopay/void_spec.rb
+++ b/spec/judopay/void_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require_relative '../../lib/judopay/models/void'
 

--- a/spec/judopay/web_payments/payment_spec.rb
+++ b/spec/judopay/web_payments/payment_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require_relative '../../../lib/judopay/models/web_payments/payment'
 

--- a/spec/judopay/web_payments/preauth_spec.rb
+++ b/spec/judopay/web_payments/preauth_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require_relative '../../../lib/judopay/models/web_payments/preauth'
 

--- a/spec/judopay/web_payments/transaction_spec.rb
+++ b/spec/judopay/web_payments/transaction_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require_relative '../../../lib/judopay/models/web_payments/transaction'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../lib/judopay'
 require 'i18n'
 

--- a/test/additions_payment_test.rb
+++ b/test/additions_payment_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'base/integration_base'
 
 class AdditionsPaymentTest < IntegrationBase

--- a/test/authentication_test.rb
+++ b/test/authentication_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'base/integration_base'
 
 class AuthenticationTest < IntegrationBase

--- a/test/base/integration_base.rb
+++ b/test/base/integration_base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test/unit'
 require 'judopay'
 require 'judopay/error'

--- a/test/base/payments_tests.rb
+++ b/test/base/payments_tests.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../base/integration_base'
 require_relative '../helper/assertion_helper'
 

--- a/test/base/token_payment_tests.rb
+++ b/test/base/token_payment_tests.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../base/integration_base'
 require_relative '../helper/assertion_helper'
 

--- a/test/card_details_test.rb
+++ b/test/card_details_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'base/integration_base'
 
 class CardDetailsTest < IntegrationBase

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test/unit'
 require_relative '../lib/judopay'
 require_relative '../lib/judopay/error'

--- a/test/helper/assertion_helper.rb
+++ b/test/helper/assertion_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'judopay/error'
 require 'test/unit/assertions'
 

--- a/test/payment_test.rb
+++ b/test/payment_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'base/payments_tests'
 require_relative 'base/integration_base'
 

--- a/test/preauth_test.rb
+++ b/test/preauth_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'base/payments_tests'
 require_relative 'base/integration_base'
 

--- a/test/register_card_test.rb
+++ b/test/register_card_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'base/payments_tests'
 require_relative 'base/integration_base'
 

--- a/test/save_card_test.rb
+++ b/test/save_card_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'base/integration_base'
 
 class SaveCardTests < IntegrationBase

--- a/test/token_payment_test.rb
+++ b/test/token_payment_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'base/token_payment_tests'
 require_relative 'base/integration_base'
 

--- a/test/token_preauth_test.rb
+++ b/test/token_preauth_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'base/token_payment_tests'
 require_relative 'base/integration_base'
 

--- a/test/void_test.rb
+++ b/test/void_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'base/integration_base'
 
 class VoidTest < IntegrationBase


### PR DESCRIPTION
Hi,

We are trying to use the gem, but this gave us a fallback on downgrading all the gems we have, specially rails.

I have cleaned up the rubocop suggestions, and I have updated `faraday` and `hashie` gems in individual commits. They seem to be the main reason we went back a major rails version.

There's also errors mentioning your traits but I can't seem to see it in any previous PR you had until now so maybe there's been a change on how FactoryBot expects traits to work.

```bash
NoMethodError:
  undefined method 'your_consumer_reference' in 'payment_details' factory
# ./spec/factories.rb:24:in `block (2 levels) in <top (required)>'
# ./spec/factories.rb:23:in `block in <top (required)>'
# ./spec/factories.rb:22:in `<top (required)>'
# ./spec/spec_helper.rb:7:in `<top (required)>'
# ./spec/judopay/web_payments/preauth_spec.rb:3:in `<top (required)>'

An error occurred while loading ./spec/judopay/web_payments/transaction_spec.rb.
Failure/Error: your_consumer_reference 123

NoMethodError:
  undefined method 'your_consumer_reference' in 'payment_details' factory
# ./spec/factories.rb:24:in `block (2 levels) in <top (required)>'
# ./spec/factories.rb:23:in `block in <top (required)>'
# ./spec/factories.rb:22:in `<top (required)>'
# ./spec/spec_helper.rb:7:in `<top (required)>'
# ./spec/judopay/web_payments/transaction_spec.rb:3:in `<top (required)>'
No examples found.
```

![judopay](https://user-images.githubusercontent.com/136777/54351423-5ab5d880-4647-11e9-97ab-3ddd60bb0be0.png)
